### PR TITLE
Fet/improved administration

### DIFF
--- a/src/app/(private)/dashboard/users/administration/_components/update-commission-modal.tsx
+++ b/src/app/(private)/dashboard/users/administration/_components/update-commission-modal.tsx
@@ -2,7 +2,13 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
 import { traderService } from "@/app/services/traderService";
@@ -10,163 +16,213 @@ import type { Admin } from "@/app/contexts/AdminsContext";
 import { Loader2 } from "lucide-react";
 
 interface UpdateCommissionModalProps {
-    admin: Admin | null;
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-    onUpdate?: () => void;
+  admin: Admin | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUpdate?: () => void;
 }
 
 export function UpdateCommissionModal({
-    admin,
-    open,
-    onOpenChange,
-    onUpdate,
+  admin,
+  open,
+  onOpenChange,
+  onUpdate,
 }: UpdateCommissionModalProps) {
-    const [commission, setCommission] = useState<string>("");
-    const [otp, setOtp] = useState<string>("");
-    const [sessionId, setSessionId] = useState<string>("");
-    const [otpSent, setOtpSent] = useState(false);
-    const [isVerifying, setIsVerifying] = useState(false);
-    const [isSending, setIsSending] = useState(false);
-    const [isLoading, setIsLoading] = useState(false);
+  const [commission, setCommission] = useState<string>("");
+  const [otp, setOtp] = useState<string>("");
+  const [sessionId, setSessionId] = useState<string>("");
+  const [otpSent, setOtpSent] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [userRole, setUserRole] = useState<string | null>(null);
 
-    useEffect(() => {
-        if (open && admin) {
-            fetchCurrentCommission();
-        } else if (!open) {
-            setCommission("");
-            setOtp("");
-            setSessionId("");
-            setOtpSent(false);
-        }
-    }, [open, admin]);
+  useEffect(() => {
+    if (open && admin) {
+      fetchCurrentCommission();
+    } else if (!open) {
+      setCommission("");
+      setOtp("");
+      setSessionId("");
+      setOtpSent(false);
+    }
+  }, [open, admin]);
 
-    useEffect(() => {
-        if (otp.length === 6 && sessionId && !isVerifying) {
-            handleVerifyOTP();
-        }
-    }, [otp]);
+  useEffect(() => {
+    if (otp.length === 6 && sessionId && !isVerifying) {
+      handleVerifyOTP();
+    }
+  }, [otp]);
 
-    const fetchCurrentCommission = async () => {
-        if (!admin) return;
-        setIsLoading(true);
-        try {
-            const response = await traderService.getTraderWalletById(admin.id);
-            if (response.success && response.data) {
-                setCommission(response.data.commission?.toString() || "0");
-            }
-        } catch (error) {
-            setCommission("0");
-        } finally {
-            setIsLoading(false);
+  useEffect(() => {
+    const fetchUserRole = async () => {
+      const token = document.cookie
+        .split("; ")
+        .find((row) => row.startsWith("auth-token="))
+        ?.split("=")[1];
+
+      if (!token) return;
+
+      try {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_BACKEND_URL}/me`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+          },
+        );
+
+        if (response.ok) {
+          const userData = await response.json();
+          setUserRole(userData.user?.role || userData.data?.user?.role);
         }
+      } catch (error) {
+        console.error("Failed to fetch user role:", error);
+      }
     };
 
-    const handleSendOTP = async () => {
-        if (!admin || !commission) return;
+    fetchUserRole();
+  }, []);
 
-        const commissionValue = parseFloat(commission);
-        if (isNaN(commissionValue) || commissionValue < 0 || commissionValue > 3) {
-            toast.error("Please enter a valid commission percentage (0-3)");
-            return;
-        }
+  const fetchCurrentCommission = async () => {
+    if (!admin) return;
+    setIsLoading(true);
+    try {
+      const response = await traderService.getTraderWalletById(admin.id);
+      if (response.success && response.data) {
+        setCommission(response.data.commission?.toString() || "0");
+      }
+    } catch (error) {
+      setCommission("0");
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
-        setIsSending(true);
-        try {
-            const response = await traderService.sendCommissionOTP(admin.id, commissionValue);
-            setSessionId(response.sessionId);
-            setOtpSent(true);
-            toast.success("OTP sent to admin phone");
-        } catch (error: any) {
-            console.error("Failed to send OTP:", error);
-            toast.error(error.response?.data?.message || "Failed to send OTP");
-        } finally {
-            setIsSending(false);
-        }
-    };
+  const handleSendOTP = async () => {
+    if (!admin || !commission) return;
 
-    const handleVerifyOTP = async () => {
-        if (!admin || !sessionId || otp.length !== 6) return;
+    const commissionValue = parseFloat(commission);
+    if (isNaN(commissionValue) || commissionValue < 0 || commissionValue > 3) {
+      toast.error("Please enter a valid commission percentage (0-3)");
+      return;
+    }
 
-        setIsVerifying(true);
-        try {
-            await traderService.setTraderCommission(admin.id, sessionId, otp);
-            toast.success("Commission rate updated successfully");
-            if (onUpdate) onUpdate();
-            onOpenChange(false);
-        } catch (error: any) {
-            console.error("Failed to verify OTP:", error);
-            toast.error(error.response?.data?.message || "Invalid OTP");
-            setOtp("");
-        } finally {
-            setIsVerifying(false);
-        }
-    };
+    setIsSending(true);
+    try {
+      const response = await traderService.sendCommissionOTP(
+        admin.id,
+        commissionValue,
+      );
 
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="sm:max-w-106.25">
-                <DialogHeader>
-                    <DialogTitle>Update Commission</DialogTitle>
-                    <DialogDescription>
-                        Set the commission percentage for this trader.
-                    </DialogDescription>
-                </DialogHeader>
+      if (userRole === "SUPERUSER" && response.success && response.data) {
+        toast.success("Commission updated successfully");
+        if (onUpdate) onUpdate();
+        onOpenChange(false);
+      } else {
+        setSessionId(response.sessionId);
+        setOtpSent(true);
+        toast.success("OTP sent to admin phone");
+      }
+    } catch (error: any) {
+      console.error("Failed to update commission:", error);
+      toast.error(
+        error.response?.data?.message || "Failed to update commission",
+      );
+    } finally {
+      setIsSending(false);
+    }
+  };
 
-                <div className="grid gap-4 py-4">
-                    <div className="text-[0.8rem] text-muted-foreground mb-2">
-                        Trader: <span className="font-medium text-foreground">{admin?.username}</span>
-                    </div>
-                    <div className="relative">
-                        <Input
-                            id="commission"
-                            className="pr-8"
-                            type="number"
-                            step="0.1"
-                            min="0"
-                            max="3"
-                            value={commission}
-                            onChange={(e) => setCommission(e.target.value)}
-                            autoFocus
-                            disabled={isSending || isLoading || otpSent}
-                        />
-                    </div>
-                    {!otpSent && (
-                        <button
-                            onClick={handleSendOTP}
-                            disabled={isSending || !commission || isLoading}
-                            className="w-full py-2 px-4 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
-                        >
-                            {(isSending || isLoading) && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                            Set Commission
-                        </button>
-                    )}
-                    {otpSent && (
-                        <>
-                            <div className="text-sm text-muted-foreground">
-                                OTP has been sent to CEO, please contact him
-                            </div>
-                            <Input
-                                id="otp"
-                                placeholder="Enter 6-digit"
-                                type="text"
-                                maxLength={6}
-                                value={otp}
-                                onChange={(e) => setOtp(e.target.value.replace(/\D/g, ""))}
-                                autoFocus
-                                disabled={isVerifying}
-                                className="text-center text-sm"
-                            />
-                            {isVerifying && (
-                                <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                                    <Loader2 className="h-4 w-4 animate-spin" />
-                                    Verifying OTP...
-                                </div>
-                            )}
-                        </>
-                    )}
+  const handleVerifyOTP = async () => {
+    if (!admin || !sessionId || otp.length !== 6) return;
+
+    setIsVerifying(true);
+    try {
+      await traderService.setTraderCommission(admin.id, sessionId, otp);
+      toast.success("Commission rate updated successfully");
+      if (onUpdate) onUpdate();
+      onOpenChange(false);
+    } catch (error: any) {
+      console.error("Failed to verify OTP:", error);
+      toast.error(error.response?.data?.message || "Invalid OTP");
+      setOtp("");
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-106.25">
+        <DialogHeader>
+          <DialogTitle>Update Commission</DialogTitle>
+          <DialogDescription>
+            Set the commission percentage for this trader.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          <div className="text-[0.8rem] text-muted-foreground mb-2">
+            Trader:{" "}
+            <span className="font-medium text-foreground">
+              {admin?.username}
+            </span>
+          </div>
+          <div className="relative">
+            <Input
+              id="commission"
+              className="pr-8"
+              type="number"
+              step="0.1"
+              min="0"
+              max="3"
+              value={commission}
+              onChange={(e) => setCommission(e.target.value)}
+              autoFocus
+              disabled={isSending || isLoading || otpSent}
+            />
+          </div>
+          {!otpSent && (
+            <button
+              onClick={handleSendOTP}
+              disabled={isSending || !commission || isLoading}
+              className="w-full py-2 px-4 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
+            >
+              {(isSending || isLoading) && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Set Commission
+            </button>
+          )}
+          {otpSent && (
+            <>
+              <div className="text-sm text-muted-foreground">
+                OTP has been sent to CEO, please contact him
+              </div>
+              <Input
+                id="otp"
+                placeholder="Enter 6-digit"
+                type="text"
+                maxLength={6}
+                value={otp}
+                onChange={(e) => setOtp(e.target.value.replace(/\D/g, ""))}
+                autoFocus
+                disabled={isVerifying}
+                className="text-center text-sm"
+              />
+              {isVerifying && (
+                <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Verifying OTP...
                 </div>
-            </DialogContent>
-        </Dialog>
-    );
+              )}
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
 }

--- a/src/app/services/traderService.ts
+++ b/src/app/services/traderService.ts
@@ -358,12 +358,13 @@ export const traderService = {
     return response.data;
   },
 
-  setTraderCommission: async (traderId: string, sessionId: string, otp: string) => {
+  setTraderCommission: async (traderId: string, sessionId?: string, otp?: string) => {
     const axiosClient = createAxiosClient();
-    const response = await axiosClient.patch(`/traders/${traderId}/commission`, {
-      sessionId,
-      otp,
-    });
+    const payload: any = {};
+    if (sessionId) payload.sessionId = sessionId;
+    if (otp) payload.otp = otp;
+    
+    const response = await axiosClient.patch(`/traders/${traderId}/commission`, payload);
     return response.data;
   },
 


### PR DESCRIPTION
I've successfully updated the UpdateCommissionModal to bypass OTP verification for SUPERUSER role. Here's what changed:

# Changes Made:
## 1. update-commission-modal.tsx

- Modified handleSendOTP to check if the user is a SUPERUSER 
- If SUPERUSER: The backend directly updates the commission and returns success, so the modal closes immediately with a success message
- If not SUPERUSER: The normal OTP flow continues as before

## 2. traderService.ts
Updated setTraderCommission to make sessionId and otp optional parameters since SUPERUSER doesn't need them

# How it works:
## SUPERUSER flow:

- User enters commission → Clicks "Set Commission" → Backend updates directly → Success message → Modal closes
- No OTP modal shown

## Regular ADMIN flow:

- User enters commission → Clicks "Set Commission" → OTP sent → User enters OTP → Commission updated
- Same as before

The backend already handles this logic (as shown in your reference code), so the frontend now properly supports both flows without requiring sessionId/otp for SUPERUSER.